### PR TITLE
Switch Tippy to @opallabs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "test": "NODE_ENV=test nyc mocha --opts ./test/mocha.opts"
   },
   "dependencies": {
+    "@opallabs/tippy.js": "opallabs/tippy.js",
     "babel-plugin-istanbul": "^5.0.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.5",
     "babel-plugin-transform-export-extensions": "^6.22.0",
@@ -109,7 +110,6 @@
     "nyc": "^13.0.1",
     "popper.js": "^1.11.1",
     "sinon": "^6.2.0",
-    "sinon-chai": "^3.2.0",
-    "tippy.js": "^2.1.1"
+    "sinon-chai": "^3.2.0"
   }
 }

--- a/src/Tooltip/component.js
+++ b/src/Tooltip/component.js
@@ -2,10 +2,10 @@ import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 import { any, bool, number, object, oneOf, string } from 'prop-types'
 
-import tippy from 'tippy.js/dist/tippy.all.js'
+import tippy from '@opallabs/tippy.js/dist/tippy.all.js'
 
-import 'tippy.js/dist/themes/light.css'
-import 'tippy.js/dist/themes/translucent.css'
+import '@opallabs/tippy.js/dist/themes/light.css'
+import '@opallabs/tippy.js/dist/themes/translucent.css'
 
 function applyIfFunction(fn) {
   return (typeof fn === 'function') ? fn() : fn


### PR DESCRIPTION
Just switches over to our local fork of TippyJS for now. If you want to test locally:

- Clone https://github.com/opallabs/tippyjs
    - Run `yarn link`
    - Run `yarn build`
- Once that finishes, run `yarn link @opallabs/tippy.js` and `yarn build` in this repo

Now you should be using our Tippy fork! (If you really want to confirm it, add a log somewhere in the Tippy constructor, and rebuild everything as outlined above, just to make sure your log gets printed correctly.)

Or if you _don't_ want to test it, just go ahead and hit that sweet, sweet "approve" button. 👍 